### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@
 *.out
 *.app
 
+# Nix
+result
+
 .cache

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ then, build the project
 ninja -C build
 ```
 
+### Nix
+
+When using any nix commands on this repository, make sure to
+allow the use of submodules:
+
+```
+# Remotely
+nix build github:neonredtech/astML?submodules=1
+
+# Locally
+nix build .?submodules=1
+```
+
 ## Including astML library in your meson project
 
 Clone this repository as a subproject:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+  
+  outputs = { self, nixpkgs, ... }: let
+    systems = [ "x86_64-linux" "aarch64" ];
+
+    forEachSystem = f: with nixpkgs.lib; foldAttrs mergeAttrs {}
+      (lists.forEach systems (system:
+        mapAttrs (name: value: { ${system} = value; }) (f system)
+      ));
+  in forEachSystem (system: let
+    pkgs = nixpkgs.legacyPackages.${system};
+  in rec {
+    devShells.default = pkgs.mkShell {
+      packages = with pkgs; [
+        gdb
+      ];
+
+      inputsFrom = [
+        packages.default
+      ];
+    };
+
+    packages.default = let
+      gcc = pkgs.gcc14;
+    in pkgs.stdenv.mkDerivation {
+      name  = "astML";
+
+      src = ./.;
+
+      nativeBuildInputs = [ gcc ] ++ (with pkgs; [
+        meson
+        ninja
+        cmake
+
+        ccache
+        
+        boost
+        antlr
+      ]);
+
+      configurePhase = "CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ meson setup ${./.} build";
+      
+      buildPhase = "ninja -C build";
+      
+      installPhase = "mkdir -p $out/bin && mv ./build/astml $out/bin/";
+    };
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
       
     in pkgs.stdenv.mkDerivation {
       name  = "astML";
+      pname = "astml";
 
       src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,12 @@
 
     packages.default = let
       gcc = pkgs.gcc14;
+      
+      meson-options = "-Dgoogletest_dir=${pkgs.fetchzip {
+        url = "https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip";
+        hash = "sha256-SjlJxushfry13RGA7BCjYC9oZqV4z6x8dOiHfl/wpF0=";
+      }}";
+      
     in pkgs.stdenv.mkDerivation {
       name  = "astML";
 
@@ -41,7 +47,7 @@
         antlr
       ]);
 
-      configurePhase = "CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ meson setup ${./.} build";
+      configurePhase = "CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ meson setup ${meson-options} ${./.} build";
       
       buildPhase = "ninja -C build";
       

--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,14 @@ gen_parsers = custom_target(
 
 
 cmake = import('cmake')
-antlr4_proj = cmake.subproject('antlr4_CppRuntime')
+
+antlr4_opts = cmake.subproject_options()
+
+if get_option('googletest_dir') != ''
+   antlr4_opts.add_cmake_defines({'FETCHCONTENT_SOURCE_DIR_GOOGLETEST': get_option('googletest_dir')})
+endif
+
+antlr4_proj = cmake.subproject('antlr4_CppRuntime', options: antlr4_opts)
 
 pugixml_proj = cmake.subproject('pugixml')
 

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('googletest_dir', type : 'string', value : '', description : 'googletest source directory for CMake')


### PR DESCRIPTION
Dependencies can now be specified and automatically managed through Nix.

Since submodules are not used by default, you need to explicitly enable them in the flake URL or path. When building locally, use `nix build .?submodules=1`.

`nix develop` gives you a shell with all build dependencies and other tools. Building normally is still supported as well.