### PR TITLE
Update Nix section on README to account for submodule quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ allow the use of submodules:
 
 ```
 # Remotely
-nix build github:neonredtech/astML?submodules=1
+nix build "git+https://github.com/neonredtech/astML?submodules=1"
 
 # Locally
+git submodule update --init --recursive
 nix build .?submodules=1
 ```
 


### PR DESCRIPTION
Currently, Nix treats submodules in GitHub repositories differently from submodules in generic git repositories, which has undesired effects such as not pulling the submodules when using `nix foo github:user/repo?submodules=1`, despite submodules being enabled.

The single commit on this PR updates the README file to account for that by explicitly fetching the repository with the generic git fetcher.